### PR TITLE
fix: remove specs on cryptographic hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,11 @@ Implement a modern cryptographic encryption method:
 
 Your team must implement hashing methods for credit card objects. Recall that all objects in Ruby have a `hash` method by default. However, this method does not use the contents of their objects to produce hashes. Furthermore, this hash method cannot produce a cryptographically strong hash.
 
-- Override the default hash: Override the default `hash` method of CreditCard to hash the serialized data of the card. Credit cards with identical information should produce identical hashes. Do not use any cryptographic hashing method here.
-- Create a cryptographic hash: Implement the `secure_hash` method to produce a SHA256 hash (return a hexadecimal string). Credit cards with identical information should produce identical secure hashes.
+- Override the default hash: Override the default `hash` method of CreditCard to hash the serialized data of the card *using a cryptographic hash*. Credit cards with identical information should produce identical hashes.
 - BUT FIRST: look at the hashing test specs in `spec/hash_spec.rb`
   - *Implement all the test descriptions* (you are welcome to add your own as well)
   - make sure your implemented tests *all fail* before writing *any* code!
   - make sure they pass *one-by-one* while writing code :)
 - We are coming to the end of this assignment -- time to do some cleanup:
   - Add references in `Gemfile` to all the gems you are using in your code and test files.
-    (see <http://bundler.io> for what to put in a `Gemfile`)
   - run `rubocop` on all your code to see if your code style is appropriate

--- a/spec/crypto_spec.rb
+++ b/spec/crypto_spec.rb
@@ -3,6 +3,7 @@
 require_relative '../credit_card'
 require_relative '../substitution_cipher'
 require 'minitest/autorun'
+require 'minitest/rg'
 
 describe 'Test card info encryption' do
   before do

--- a/spec/hash_spec.rb
+++ b/spec/hash_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative '../credit_card'
 require 'minitest/autorun'
+require 'minitest/rg'
 
 # Feel free to replace the contents of cards with data from your own yaml file
 card_details = [
@@ -24,27 +25,11 @@ cards = card_details.map do |c|
 end
 
 describe 'Test hashing requirements' do
-  describe 'Test regular hashing' do
-    describe 'Check hashes are consistently produced' do
-      # TODO: Check that each card produces the same hash if hashed repeatedly
-    end
-
-    describe 'Check for unique hashes' do
-      # TODO: Check that each card produces a different hash than other cards
-    end
+  describe 'Check hashes are consistently produced' do
+    # TODO: Check that each card produces the same hash if hashed repeatedly
   end
 
-  describe 'Test cryptographic hashing' do
-    describe 'Check hashes are consistently produced' do
-      # TODO: Check that each card produces the same hash if hashed repeatedly
-    end
-
-    describe 'Check for unique hashes' do
-      # TODO: Check that each card produces a different hash than other cards
-    end
-
-    describe 'Check regular hash not same as cryptographic hash' do
-      # TODO: Check that each card's hash is different from its hash_secure
-    end
+  describe 'Check for unique hashes' do
+    # TODO: Check that each card produces a different hash than other cards
   end
 end

--- a/spec/luhn_spec_long.rb
+++ b/spec/luhn_spec_long.rb
@@ -2,6 +2,7 @@
 
 require_relative '../credit_card'
 require 'minitest/autorun'
+require 'minitest/rg'
 require 'yaml'
 
 cards = YAML.load_file 'spec/test_numbers.yml'


### PR DESCRIPTION
The modifications made by our professor. It seems like we can merge it with no issue.